### PR TITLE
Add gcode file sharing for research

### DIFF
--- a/tools/gcode-viewer/index.html
+++ b/tools/gcode-viewer/index.html
@@ -161,6 +161,16 @@
                     </span>
                     <span class="view-toggle-text">Travel</span>
                 </label>
+                <div class="toolbar-divider"></div>
+                <label class="view-toggle">
+                    <input type="checkbox" id="shareForResearch" checked>
+                    <span class="view-toggle-indicator">
+                        <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7"/>
+                        </svg>
+                    </span>
+                    <span class="view-toggle-text" title="Files are sent to Rep5x for 5-axis printing research. Never shared or distributed.">Share for research</span>
+                </label>
             </div>
 
             <!-- Printhead Select -->
@@ -332,6 +342,7 @@
     <script src="js/file-handler.js"></script>
     <script src="js/ui-controller.js"></script>
     <script src="js/toolbar-ui.js"></script>
+    <script src="js/share-handler.js"></script>
     <script src="js/app.js"></script>
 </body>
 </html>

--- a/tools/gcode-viewer/js/app.js
+++ b/tools/gcode-viewer/js/app.js
@@ -10,6 +10,7 @@ class GcodePreviewerApp {
         this.collisionDetector = new CollisionDetector();
         this.ikReverser = null;
         this.calibrationReverser = null;
+        this.shareHandler = new ShareHandler();
         this.currentData = null;
 
         // Reversal settings
@@ -26,6 +27,12 @@ class GcodePreviewerApp {
             this.ui.setupEventListeners();
             this.initializePrintheadSelector();
             this.ui.hideLoading();
+
+            // Restore share preference
+            const shareCheckbox = document.getElementById('shareForResearch');
+            if (shareCheckbox) {
+                shareCheckbox.checked = this.shareHandler.isEnabled();
+            }
         } catch (error) {
             console.error('Error initializing app:', error);
             document.getElementById('loading').innerHTML =
@@ -56,6 +63,7 @@ class GcodePreviewerApp {
         this.ui.onShowRealisticHeadChange = (show) => this.animationEngine.showRealisticPrinthead(show);
         this.ui.onShowCollisionsChange = (enabled) => this.handleCollisionToggle(enabled);
         this.ui.onShowTravelMovesChange = (show) => this.animationEngine.setShowTravelMoves(show);
+        this.ui.onShareForResearchChange = (enabled) => this.shareHandler.setEnabled(enabled);
         this.ui.onPrintheadChange = (printheadId) => this.handlePrintheadChange(printheadId);
         this.ui.onManualModeChange = (enabled) => this.toggleManualMode(enabled);
         this.ui.onApplyManual = () => this.applyManualSettings();
@@ -113,6 +121,9 @@ class GcodePreviewerApp {
 
             this.ui.enableControls();
             this.ui.hideLoading();
+
+            // Share file for research if enabled
+            this.shareHandler.share(file, parseResult.metadata, this.parser.getStatistics());
 
         } catch (error) {
             console.error('Error loading G-code file:', error);

--- a/tools/gcode-viewer/js/share-handler.js
+++ b/tools/gcode-viewer/js/share-handler.js
@@ -1,0 +1,41 @@
+// Share handler for Rep5x G-code viewer
+// Sends uploaded gcode files to Rep5x for 5-axis printing research (when enabled)
+
+class ShareHandler {
+    constructor() {
+        this.endpoint = 'https://rep5x.com/gcode-share';
+        this.storageKey = 'gcodeViewer_shareForResearch';
+    }
+
+    isEnabled() {
+        const stored = localStorage.getItem(this.storageKey);
+        return stored === null ? true : stored === 'true';
+    }
+
+    setEnabled(enabled) {
+        localStorage.setItem(this.storageKey, String(enabled));
+    }
+
+    share(file, metadata, statistics) {
+        if (!this.isEnabled()) return;
+
+        try {
+            const formData = new FormData();
+            formData.append('file', file);
+            formData.append('metadata', JSON.stringify({
+                ...metadata,
+                totalCommands: statistics?.totalCommands,
+                layers: statistics?.layers,
+                printDistance: statistics?.printDistance,
+                estimatedTime: statistics?.estimatedTime,
+            }));
+
+            fetch(this.endpoint, {
+                method: 'POST',
+                body: formData,
+            }).catch(err => console.warn('Gcode share failed:', err));
+        } catch (err) {
+            console.warn('Gcode share failed:', err);
+        }
+    }
+}

--- a/tools/gcode-viewer/js/ui-controller.js
+++ b/tools/gcode-viewer/js/ui-controller.js
@@ -28,6 +28,7 @@ class UIController {
             showRealisticHead: document.getElementById('showRealisticHead'),
             showCollisions: document.getElementById('showCollisions'),
             showTravelMoves: document.getElementById('showTravelMoves'),
+            shareForResearch: document.getElementById('shareForResearch'),
             collisionInfo: document.getElementById('collisionInfo'),
             collisionCount: document.getElementById('collisionCount'),
 
@@ -68,6 +69,7 @@ class UIController {
         this.onShowCollisionsChange = null;
         this.onShowTravelMovesChange = null;
         this.onPrintheadChange = null;
+        this.onShareForResearchChange = null;
         this.onManualModeChange = null;
         this.onApplyManual = null;
     }
@@ -124,6 +126,12 @@ class UIController {
         if (this.elements.showTravelMoves) {
             this.elements.showTravelMoves.addEventListener('change', (e) => {
                 if (this.onShowTravelMovesChange) this.onShowTravelMovesChange(e.target.checked);
+            });
+        }
+
+        if (this.elements.shareForResearch) {
+            this.elements.shareForResearch.addEventListener('change', (e) => {
+                if (this.onShareForResearchChange) this.onShareForResearchChange(e.target.checked);
             });
         }
 

--- a/website/functions/gcode-share.js
+++ b/website/functions/gcode-share.js
@@ -1,0 +1,174 @@
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': 'https://tools.rep5x.com',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Content-Type': 'application/json'
+};
+
+export async function onRequestOptions() {
+  return new Response(null, { status: 200, headers: CORS_HEADERS });
+}
+
+function formatBytes(bytes) {
+  if (bytes === 0) return '0 Bytes';
+  const k = 1024;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+}
+
+function arrayBufferToBase64(buffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  const chunkSize = 8192;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode.apply(null, bytes.subarray(i, i + chunkSize));
+  }
+  return btoa(binary);
+}
+
+function buildMetadataHtml(metadata) {
+  const fields = [
+    ['Filename', metadata.filename],
+    ['File Size', metadata.fileSize],
+    ['Shape', metadata.shape],
+    ['Diameter', metadata.diameter ? `${metadata.diameter}mm` : null],
+    ['Height', metadata.height ? `${metadata.height}mm` : null],
+    ['Layer Height', metadata.layerHeight ? `${metadata.layerHeight}mm` : null],
+    ['Wall Thickness', metadata.wallThickness ? `${metadata.wallThickness}mm` : null],
+    ['Print Speed', metadata.printSpeed ? `${metadata.printSpeed}mm/s` : null],
+    ['Generated On', metadata.generatedOn],
+    ['Inverse Kinematics', metadata.inverseKinematics ? 'Yes' : 'No'],
+    ['LC Parameter', metadata.inverseKinematics ? metadata.lcParameter : null],
+    ['LB Parameter', metadata.inverseKinematics ? metadata.lbParameter : null],
+    ['C-Axis Optimization', metadata.cAxisOptimization ? 'Yes' : null],
+    ['Total Commands', metadata.totalCommands],
+    ['Layers', metadata.layers],
+    ['Print Distance', metadata.printDistance],
+    ['Estimated Time', metadata.estimatedTime],
+  ];
+
+  const rows = fields
+    .filter(([, value]) => value != null && value !== '')
+    .map(([label, value]) =>
+      `<tr><td style="padding:6px 12px;font-weight:bold;color:#4a5568;">${label}</td><td style="padding:6px 12px;">${value}</td></tr>`
+    )
+    .join('');
+
+  return `<table style="border-collapse:collapse;width:100%;font-family:Arial,sans-serif;">${rows}</table>`;
+}
+
+export async function onRequestPost({ request, env }) {
+  try {
+    const formData = await request.formData();
+    const file = formData.get('file');
+    const metadataStr = formData.get('metadata');
+
+    if (!file) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'No file provided' }),
+        { status: 400, headers: CORS_HEADERS }
+      );
+    }
+
+    const metadata = metadataStr ? JSON.parse(metadataStr) : {};
+    const filename = file.name || 'unknown.gcode';
+    const fileSize = file.size;
+    const metadataHtml = buildMetadataHtml({ ...metadata, filename, fileSize: formatBytes(fileSize) });
+
+    // Read the file once and reuse the buffer
+    const arrayBuffer = await file.arrayBuffer();
+
+    let emailBody;
+    let attachments;
+    let r2Key = null;
+
+    if (fileSize < 10 * 1024 * 1024) {
+      // Small file: try to attach directly
+      const base64 = arrayBufferToBase64(arrayBuffer);
+      attachments = [{ filename, content: base64, encoding: 'base64' }];
+      emailBody = `
+        <h2>New G-code File Shared</h2>
+        ${metadataHtml}
+        <p style="margin-top:16px;color:#718096;">File attached to this email.</p>
+      `;
+    } else {
+      // Large file: upload to R2
+      r2Key = `${new Date().toISOString().split('T')[0]}/${Date.now()}-${filename}`;
+      await env.GCODE_BUCKET.put(r2Key, arrayBuffer, {
+        httpMetadata: { contentType: 'application/octet-stream' },
+        customMetadata: { originalName: filename }
+      });
+
+      emailBody = `
+        <h2>New G-code File Shared</h2>
+        ${metadataHtml}
+        <p style="margin-top:16px;"><strong>File too large to attach (${formatBytes(fileSize)}).</strong></p>
+        <p>Stored in R2: <code>${r2Key}</code></p>
+        <p style="color:#718096;">Access via Cloudflare dashboard &rarr; R2 &rarr; rep5x-gcode-research bucket.</p>
+      `;
+      attachments = undefined;
+    }
+
+    const emailPayload = {
+      from: 'Rep5x Gcode Viewer <noreply@rep5x.com>',
+      to: 'dennis@rep5x.com',
+      subject: `[Gcode Share] ${filename}`,
+      html: emailBody,
+    };
+    if (attachments) {
+      emailPayload.attachments = attachments;
+    }
+
+    const emailResponse = await fetch('https://api.emailit.com/v1/emails', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${env.EMAILIT_API_KEY}`
+      },
+      body: JSON.stringify(emailPayload)
+    });
+
+    // If attachment-based email failed, fall back to R2 path
+    if (!emailResponse.ok && attachments) {
+      console.error('EmailIt attachment failed, falling back to R2:', await emailResponse.text());
+
+      r2Key = `${new Date().toISOString().split('T')[0]}/${Date.now()}-${filename}`;
+      await env.GCODE_BUCKET.put(r2Key, arrayBuffer, {
+        httpMetadata: { contentType: 'application/octet-stream' },
+        customMetadata: { originalName: filename }
+      });
+
+      await fetch('https://api.emailit.com/v1/emails', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${env.EMAILIT_API_KEY}`
+        },
+        body: JSON.stringify({
+          from: 'Rep5x Gcode Viewer <noreply@rep5x.com>',
+          to: 'dennis@rep5x.com',
+          subject: `[Gcode Share] ${filename}`,
+          html: `
+            <h2>New G-code File Shared</h2>
+            ${metadataHtml}
+            <p style="margin-top:16px;"><strong>Attachment failed, file stored in R2.</strong></p>
+            <p>Stored in R2: <code>${r2Key}</code></p>
+            <p style="color:#718096;">Access via Cloudflare dashboard &rarr; R2 &rarr; rep5x-gcode-research bucket.</p>
+          `
+        })
+      });
+    }
+
+    return new Response(
+      JSON.stringify({ success: true }),
+      { status: 200, headers: CORS_HEADERS }
+    );
+  } catch (error) {
+    console.error('gcode-share error:', error);
+    return new Response(
+      JSON.stringify({ success: false, error: 'Internal error' }),
+      { status: 500, headers: CORS_HEADERS }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a "Share for research" toggle to the gcode viewer secondary toolbar
- When enabled, uploaded gcode files + parsed metadata are sent to dennis@rep5x.com via a new Cloudflare Pages Function
- Small files (<10MB) attached directly via EmailIt API; large files stored in R2 with a link emailed instead
- Fire-and-forget: sharing happens in the background without interrupting the viewer

## Test plan
- [ ] Load a gcode file with "Share for research" enabled, verify email arrives with metadata and attachment
- [ ] Load a large gcode file (>10MB), verify R2 upload and email with R2 key
- [ ] Toggle "Share for research" off, load a file, verify no email is sent
- [ ] Verify toggle state persists across page reloads via localStorage
- [ ] Verify CORS preflight works from tools.rep5x.com origin