### PR TITLE
Add Ender 5 Pro preset and endstop state config

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -159,6 +159,39 @@ jobs:
             sed -i "s/^#define INVERT_E0_DIR.*/#define INVERT_E0_DIR $INVERT_E/" marlin/Marlin/Configuration.h
           fi
 
+          # === ENDSTOP HIT STATES ===
+          ENDSTOP_X=$(echo "$CUSTOMIZATIONS" | jq -r '.endstopX // empty')
+          ENDSTOP_Y=$(echo "$CUSTOMIZATIONS" | jq -r '.endstopY // empty')
+          ENDSTOP_Z=$(echo "$CUSTOMIZATIONS" | jq -r '.endstopZ // empty')
+          ENDSTOP_C=$(echo "$CUSTOMIZATIONS" | jq -r '.endstopC // empty')
+          ENDSTOP_B=$(echo "$CUSTOMIZATIONS" | jq -r '.endstopB // empty')
+
+          if [ -n "$ENDSTOP_X" ]; then
+            sed -i "s/^#define X_MIN_ENDSTOP_HIT_STATE.*/#define X_MIN_ENDSTOP_HIT_STATE $ENDSTOP_X/" marlin/Marlin/Configuration.h
+            sed -i "s/^#define X_MAX_ENDSTOP_HIT_STATE.*/#define X_MAX_ENDSTOP_HIT_STATE $ENDSTOP_X/" marlin/Marlin/Configuration.h
+            echo "Set X endstop hit state to $ENDSTOP_X"
+          fi
+          if [ -n "$ENDSTOP_Y" ]; then
+            sed -i "s/^#define Y_MIN_ENDSTOP_HIT_STATE.*/#define Y_MIN_ENDSTOP_HIT_STATE $ENDSTOP_Y/" marlin/Marlin/Configuration.h
+            sed -i "s/^#define Y_MAX_ENDSTOP_HIT_STATE.*/#define Y_MAX_ENDSTOP_HIT_STATE $ENDSTOP_Y/" marlin/Marlin/Configuration.h
+            echo "Set Y endstop hit state to $ENDSTOP_Y"
+          fi
+          if [ -n "$ENDSTOP_Z" ]; then
+            sed -i "s/^#define Z_MIN_ENDSTOP_HIT_STATE.*/#define Z_MIN_ENDSTOP_HIT_STATE $ENDSTOP_Z/" marlin/Marlin/Configuration.h
+            sed -i "s/^#define Z_MAX_ENDSTOP_HIT_STATE.*/#define Z_MAX_ENDSTOP_HIT_STATE $ENDSTOP_Z/" marlin/Marlin/Configuration.h
+            echo "Set Z endstop hit state to $ENDSTOP_Z"
+          fi
+          if [ -n "$ENDSTOP_C" ]; then
+            sed -i "s/^#define I_MIN_ENDSTOP_HIT_STATE.*/#define I_MIN_ENDSTOP_HIT_STATE $ENDSTOP_C/" marlin/Marlin/Configuration.h
+            sed -i "s/^#define I_MAX_ENDSTOP_HIT_STATE.*/#define I_MAX_ENDSTOP_HIT_STATE $ENDSTOP_C/" marlin/Marlin/Configuration.h
+            echo "Set C endstop hit state to $ENDSTOP_C"
+          fi
+          if [ -n "$ENDSTOP_B" ]; then
+            sed -i "s/^#define J_MIN_ENDSTOP_HIT_STATE.*/#define J_MIN_ENDSTOP_HIT_STATE $ENDSTOP_B/" marlin/Marlin/Configuration.h
+            sed -i "s/^#define J_MAX_ENDSTOP_HIT_STATE.*/#define J_MAX_ENDSTOP_HIT_STATE $ENDSTOP_B/" marlin/Marlin/Configuration.h
+            echo "Set B endstop hit state to $ENDSTOP_B"
+          fi
+
           # === IK PARAMETERS ===
           IK_LC=$(echo "$CUSTOMIZATIONS" | jq -r '.ikLC // empty')
           IK_LB=$(echo "$CUSTOMIZATIONS" | jq -r '.ikLB // empty')

--- a/tools/firmware-builder/index.html
+++ b/tools/firmware-builder/index.html
@@ -180,6 +180,7 @@
                                 <option value="ender3v3se" selected>Ender 3 V3 SE (220×220×270)</option>
                                 <option value="ender3pro">Ender 3 Pro (220×220×250)</option>
                                 <option value="ender3v2">Ender 3 V2 (220×220×250)</option>
+                                <option value="ender5pro">Ender 5 Pro (220×220×300)</option>
                             </select>
                         </div>
 
@@ -660,6 +661,51 @@
                                 <p class="text-sm text-blue-800">
                                     <strong>C-axis (yaw):</strong> Inverted by default for CNC convention where positive C = clockwise when viewed from above.
                                 </p>
+                            </div>
+                        </div>
+
+                        <div class="section-divider">
+                            <span>Endstop switches</span>
+                        </div>
+
+                        <p class="text-sm text-gray-600 mb-2">Select <strong>NO</strong> (normally open) or <strong>NC</strong> (normally closed) based on your switch wiring.</p>
+
+                        <!-- Endstop hit states -->
+                        <div class="grid grid-cols-3 gap-4">
+                            <div>
+                                <label class="block text-sm text-gray-600 mb-1">X endstop</label>
+                                <select id="endstopX" class="config-input w-full">
+                                    <option value="HIGH" selected>NO (normally open)</option>
+                                    <option value="LOW">NC (normally closed)</option>
+                                </select>
+                            </div>
+                            <div>
+                                <label class="block text-sm text-gray-600 mb-1">Y endstop</label>
+                                <select id="endstopY" class="config-input w-full">
+                                    <option value="HIGH" selected>NO (normally open)</option>
+                                    <option value="LOW">NC (normally closed)</option>
+                                </select>
+                            </div>
+                            <div>
+                                <label class="block text-sm text-gray-600 mb-1">Z endstop</label>
+                                <select id="endstopZ" class="config-input w-full">
+                                    <option value="HIGH" selected>NO (normally open)</option>
+                                    <option value="LOW">NC (normally closed)</option>
+                                </select>
+                            </div>
+                            <div>
+                                <label class="block text-sm text-gray-600 mb-1">C endstop</label>
+                                <select id="endstopC" class="config-input w-full">
+                                    <option value="HIGH" selected>NO (normally open)</option>
+                                    <option value="LOW">NC (normally closed)</option>
+                                </select>
+                            </div>
+                            <div>
+                                <label class="block text-sm text-gray-600 mb-1">B endstop</label>
+                                <select id="endstopB" class="config-input w-full">
+                                    <option value="HIGH">NO (normally open)</option>
+                                    <option value="LOW" selected>NC (normally closed)</option>
+                                </select>
                             </div>
                         </div>
                     </div>

--- a/tools/firmware-builder/js/app.js
+++ b/tools/firmware-builder/js/app.js
@@ -31,6 +31,15 @@ const printerPresets = {
         xHomeDir: -1,
         yHomeDir: -1,
         zHomeDir: -1
+    },
+    'ender5pro': {
+        name: 'Ender 5 Pro',
+        xBedSize: 220,
+        yBedSize: 220,
+        zMaxPos: 300,
+        xHomeDir: -1,
+        yHomeDir: -1,
+        zHomeDir: 1
     }
 };
 
@@ -96,6 +105,13 @@ const wizardState = {
         invertC: true,
         invertB: false,
         invertE: false,
+
+        // Step 4: Endstop hit state (HIGH = NO, LOW = NC)
+        endstopX: 'HIGH',
+        endstopY: 'HIGH',
+        endstopZ: 'HIGH',
+        endstopC: 'HIGH',
+        endstopB: 'LOW',
 
         // Step 6: Kinematics
         ikLC: 2.30,
@@ -223,7 +239,12 @@ function setupInputListeners() {
         { id: 'socketZ', key: 'socketZ' },
         { id: 'socketC', key: 'socketC' },
         { id: 'socketB', key: 'socketB' },
-        { id: 'socketE', key: 'socketE' }
+        { id: 'socketE', key: 'socketE' },
+        { id: 'endstopX', key: 'endstopX' },
+        { id: 'endstopY', key: 'endstopY' },
+        { id: 'endstopZ', key: 'endstopZ' },
+        { id: 'endstopC', key: 'endstopC' },
+        { id: 'endstopB', key: 'endstopB' }
     ];
 
     selectInputsString.forEach(({ id, key }) => {
@@ -547,6 +568,7 @@ function formatPrinterName(value) {
         'ender3v3se': 'Ender 3 V3 SE',
         'ender3pro': 'Ender 3 Pro',
         'ender3v2': 'Ender 3 V2',
+        'ender5pro': 'Ender 5 Pro',
         'custom': 'Custom'
     };
     return names[value] || value;
@@ -695,6 +717,12 @@ async function buildFirmware() {
             invertC: config.invertC,
             invertB: config.invertB,
             invertE: config.invertE,
+            // Endstop hit states
+            endstopX: config.endstopX,
+            endstopY: config.endstopY,
+            endstopZ: config.endstopZ,
+            endstopC: config.endstopC,
+            endstopB: config.endstopB,
             // IK parameters
             ikLC: config.ikLC,
             ikLB: config.ikLB,
@@ -1022,6 +1050,13 @@ function applyImportedConfig(config) {
     invertFields.forEach(field => {
         const el = document.getElementById(field);
         if (el) el.checked = config[field];
+    });
+
+    // === Endstop hit states ===
+    const endstopFields = ['endstopX', 'endstopY', 'endstopZ', 'endstopC', 'endstopB'];
+    endstopFields.forEach(field => {
+        const el = document.getElementById(field);
+        if (el && config[field]) el.value = config[field];
     });
 
     // === IK Parameters ===

--- a/tools/firmware-builder/worker/worker.js
+++ b/tools/firmware-builder/worker/worker.js
@@ -124,6 +124,12 @@ async function handleBuildRequest(request, env, corsHeaders) {
     invertC: body.invertC,
     invertB: body.invertB,
     invertE: body.invertE,
+    // Endstop hit states
+    endstopX: body.endstopX,
+    endstopY: body.endstopY,
+    endstopZ: body.endstopZ,
+    endstopC: body.endstopC,
+    endstopB: body.endstopB,
     // IK parameters
     ikLC: body.ikLC,
     ikLB: body.ikLB,
@@ -286,6 +292,12 @@ async function handleConfigRequest(buildId, env, corsHeaders) {
     invertC: buildData.invertC,
     invertB: buildData.invertB,
     invertE: buildData.invertE,
+    // Endstop hit states
+    endstopX: buildData.endstopX,
+    endstopY: buildData.endstopY,
+    endstopZ: buildData.endstopZ,
+    endstopC: buildData.endstopC,
+    endstopB: buildData.endstopB,
     // IK parameters
     ikLC: buildData.ikLC,
     ikLB: buildData.ikLB,


### PR DESCRIPTION
## Summary
- Add Ender 5 Pro preset (220×220×300, Z homes MAX for Rep5x)
- Add per-axis endstop hit state toggles (NO/NC) in step 4
- Wire endstop state through worker and build workflow

## Test plan
- [ ] Select Ender 5 Pro preset and verify dimensions/homing apply
- [ ] Toggle endstop NC on an axis and verify `*_ENDSTOP_HIT_STATE LOW` in generated config