### PR TITLE
Add baud rate selector and fix home() timeout

### DIFF
--- a/tools/calibrator/index.html
+++ b/tools/calibrator/index.html
@@ -169,8 +169,11 @@
                                     <span class="status-dot disconnected" id="serialStatus"></span>
                                     <span class="ml-2 text-sm" id="serialStatusText">Not connected</span>
                                 </div>
-                                <button id="connectBtn"
-                                    class="btn-primary px-4 py-2 rounded-lg text-sm font-medium">Connect</button>
+                                <div class="flex items-center gap-3">
+                                    <span id="baudSelector"></span>
+                                    <button id="connectBtn"
+                                        class="btn-primary px-4 py-2 rounded-lg text-sm font-medium">Connect</button>
+                                </div>
                             </div>
                             <p class="text-xs text-gray-500">
                                 Click Connect and select your printer's serial port (usually contains "USB" or "CH340").
@@ -832,6 +835,7 @@
     <script src="../shared/file-downloader.js"></script>
     <script src="../shared/wizard-framework.js"></script>
     <script src="../shared/printer-interface.js"></script>
+    <script src="../shared/baud-selector.js"></script>
     <script src="../shared/camera-manager.js"></script>
     <script src="../shared/inverse-kinematics.js"></script>
     <script src="../shared/calibration-corrector.js"></script>
@@ -849,6 +853,7 @@
     <script src="js/calibration.js"></script>
     <script src="js/results.js"></script>
     <script src="js/app.js"></script>
+    <script>BaudSelector.mount('baudSelector');</script>
 </body>
 
 </html>

--- a/tools/lc-lb-measure/index.html
+++ b/tools/lc-lb-measure/index.html
@@ -185,9 +185,12 @@
                                     <span class="status-dot disconnected" id="serialStatus"></span>
                                     <span class="ml-2 text-sm" id="serialStatusText">Not connected</span>
                                 </div>
-                                <button id="connectBtn" class="btn-primary px-4 py-2 rounded-lg text-sm font-medium">
-                                    Connect
-                                </button>
+                                <div class="flex items-center gap-3">
+                                    <span id="baudSelector"></span>
+                                    <button id="connectBtn" class="btn-primary px-4 py-2 rounded-lg text-sm font-medium">
+                                        Connect
+                                    </button>
+                                </div>
                             </div>
                             <p class="text-xs text-gray-500">
                                 Click Connect and select your printer's serial port (usually contains "USB" or "CH340").
@@ -1005,6 +1008,7 @@
     <script src="../shared/footer.js"></script>
     <script src="../shared/wizard-framework.js"></script>
     <script src="../shared/printer-interface.js"></script>
+    <script src="../shared/baud-selector.js"></script>
     <!-- Tool-specific scripts -->
     <script src="js/measurement-engine.js"></script>
     <script src="../shared/camera-manager.js"></script>
@@ -1016,6 +1020,7 @@
     <script src="js/lb-measure.js"></script>
     <script src="js/results.js"></script>
     <script src="js/app.js"></script>
+    <script>BaudSelector.mount('baudSelector');</script>
 </body>
 
 </html>

--- a/tools/printer-control/index.html
+++ b/tools/printer-control/index.html
@@ -33,6 +33,7 @@
                         <input type="checkbox" id="testModeToggle" class="form-checkbox h-4 w-4 text-primary rounded">
                         Test mode
                     </label>
+                    <span id="baudSelector"></span>
                     <button id="connectBtn" class="btn-primary px-5 py-2.5 rounded-lg font-medium flex items-center gap-2">
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
@@ -373,8 +374,10 @@
     <script src="../shared/storage-manager.js"></script>
     <script src="../shared/footer.js"></script>
     <script src="../shared/printer-interface.js"></script>
+    <script src="../shared/baud-selector.js"></script>
     <!-- Tool-specific scripts -->
     <script src="js/app.js"></script>
+    <script>BaudSelector.mount('baudSelector');</script>
 </body>
 
 </html>

--- a/tools/printer-setup/index.html
+++ b/tools/printer-setup/index.html
@@ -92,9 +92,12 @@
                                     <span class="status-dot disconnected" id="serialStatus"></span>
                                     <span class="ml-2 text-sm" id="serialStatusText">Not connected</span>
                                 </div>
-                                <button id="connectBtn" class="btn-primary px-4 py-2 rounded-lg text-sm font-medium">
-                                    Connect
-                                </button>
+                                <div class="flex items-center gap-3">
+                                    <span id="baudSelector"></span>
+                                    <button id="connectBtn" class="btn-primary px-4 py-2 rounded-lg text-sm font-medium">
+                                        Connect
+                                    </button>
+                                </div>
                             </div>
                             <p class="text-xs text-gray-500">
                                 Connect via USB serial to control and configure your printer.
@@ -846,6 +849,7 @@
     <script src="../shared/footer.js"></script>
     <script src="../shared/wizard-framework.js"></script>
     <script src="../shared/printer-interface.js"></script>
+    <script src="../shared/baud-selector.js"></script>
     <!-- Tool-specific scripts -->
     <script src="../shared/step-connect-base.js"></script>
     <script src="js/connect.js"></script>
@@ -856,5 +860,6 @@
     <script src="js/z-axis.js"></script>
     <script src="js/apply.js"></script>
     <script src="js/app.js"></script>
+    <script>BaudSelector.mount('baudSelector');</script>
 </body>
 </html>

--- a/tools/shared/baud-selector.js
+++ b/tools/shared/baud-selector.js
@@ -1,0 +1,93 @@
+/**
+ * Baud rate selector for Rep5x tools.
+ *
+ * Renders a small dropdown that lets the user pick the serial baud rate used
+ * by PrinterInterface. The choice is persisted in localStorage under the same
+ * key PrinterInterface reads (`rep5x.baudRate`), so any tool sharing
+ * PrinterInterface picks up the value automatically on next connect.
+ *
+ * Usage:
+ *   <span id="baudSelector"></span>
+ *   <script src="../shared/baud-selector.js"></script>
+ *   <script>BaudSelector.mount('baudSelector');</script>
+ */
+
+const BaudSelector = (() => {
+    const STORAGE_KEY = 'rep5x.baudRate';
+    const DEFAULT_BAUD = 250000;
+    const COMMON_RATES = [250000, 115200, 230400, 57600, 38400, 19200, 9600];
+    const CUSTOM_VALUE = 'custom';
+
+    function readStored() {
+        try {
+            const v = parseInt(localStorage.getItem(STORAGE_KEY), 10);
+            if (Number.isFinite(v) && v > 0) return v;
+        } catch (_) { /* localStorage may be unavailable */ }
+        return DEFAULT_BAUD;
+    }
+
+    function writeStored(value) {
+        try {
+            localStorage.setItem(STORAGE_KEY, String(value));
+        } catch (_) { /* ignore */ }
+    }
+
+    function getBaudRate() {
+        return readStored();
+    }
+
+    function mount(elementId) {
+        const host = document.getElementById(elementId);
+        if (!host) {
+            console.warn(`[BaudSelector] element #${elementId} not found`);
+            return null;
+        }
+
+        const current = readStored();
+        const isCustom = !COMMON_RATES.includes(current);
+
+        host.innerHTML = `
+            <label class="flex items-center gap-2 text-xs text-gray-600">
+                <span>Baud</span>
+                <select class="baud-selector-select px-2 py-1 border border-gray-300 rounded text-xs font-mono bg-white focus:outline-none focus:border-primary">
+                    ${COMMON_RATES.map(r =>
+                        `<option value="${r}"${!isCustom && r === current ? ' selected' : ''}>${r}</option>`
+                    ).join('')}
+                    <option value="${CUSTOM_VALUE}"${isCustom ? ' selected' : ''}>Custom…</option>
+                </select>
+                <input type="number" min="1" step="1" value="${current}"
+                    class="baud-selector-custom px-2 py-1 border border-gray-300 rounded text-xs font-mono bg-white focus:outline-none focus:border-primary w-24${isCustom ? '' : ' hidden'}"
+                    placeholder="baud">
+            </label>
+        `;
+
+        const select = host.querySelector('.baud-selector-select');
+        const custom = host.querySelector('.baud-selector-custom');
+
+        const persist = (raw) => {
+            const v = parseInt(raw, 10);
+            if (Number.isFinite(v) && v > 0) writeStored(v);
+        };
+
+        select.addEventListener('change', () => {
+            if (select.value === CUSTOM_VALUE) {
+                custom.classList.remove('hidden');
+                custom.focus();
+                persist(custom.value);
+            } else {
+                custom.classList.add('hidden');
+                persist(select.value);
+            }
+        });
+
+        custom.addEventListener('input', () => persist(custom.value));
+
+        return { getBaudRate };
+    }
+
+    return { mount, getBaudRate, STORAGE_KEY, DEFAULT_BAUD };
+})();
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = BaudSelector;
+}

--- a/tools/shared/printer-interface.js
+++ b/tools/shared/printer-interface.js
@@ -6,14 +6,28 @@
  */
 
 class PrinterInterface {
-    static BAUD_RATE = 115200;
+    static DEFAULT_BAUD_RATE = 250000;
+    static BAUD_STORAGE_KEY = 'rep5x.baudRate';
     static POSITION_POLL_DELAY = 500;
     static COMMAND_TIMEOUT = 30000;
+
+    /**
+     * Read the user's chosen baud from localStorage, falling back to the default.
+     * @returns {number}
+     */
+    static getStoredBaudRate() {
+        try {
+            const stored = parseInt(localStorage.getItem(PrinterInterface.BAUD_STORAGE_KEY), 10);
+            if (Number.isFinite(stored) && stored > 0) return stored;
+        } catch (_) { /* localStorage unavailable */ }
+        return PrinterInterface.DEFAULT_BAUD_RATE;
+    }
 
     /**
      * Create a new PrinterInterface
      * @param {object} options - Configuration options
      * @param {boolean} options.logResponses - Whether to log all serial responses (default: true)
+     * @param {number} options.baudRate - Override the baud rate (default: read from localStorage / DEFAULT_BAUD_RATE)
      */
     constructor(options = {}) {
         this.port = null;
@@ -27,6 +41,9 @@ class PrinterInterface {
 
         // Configuration
         this.logResponses = options.logResponses !== false; // Default to true
+        this.baudRate = Number.isFinite(options.baudRate) && options.baudRate > 0
+            ? options.baudRate
+            : PrinterInterface.getStoredBaudRate();
 
         // Command queue to prevent concurrent writes (WritableStream can only have one writer)
         this.sendQueue = Promise.resolve();
@@ -146,16 +163,18 @@ class PrinterInterface {
      */
     async openPort() {
         try {
-            // Open the port
+            // Re-read baud at open time so a selector change takes effect on reconnect
+            this.baudRate = PrinterInterface.getStoredBaudRate();
+
             await this.port.open({
-                baudRate: PrinterInterface.BAUD_RATE,
+                baudRate: this.baudRate,
                 dataBits: 8,
                 stopBits: 1,
                 parity: 'none',
                 flowControl: 'none'
             });
 
-            this.log(`Connected at ${PrinterInterface.BAUD_RATE} baud`);
+            this.log(`Connected at ${this.baudRate} baud`);
 
             // Start reading
             this.startReading();
@@ -733,16 +752,11 @@ class PrinterInterface {
     /**
      * Home specified axes
      * @param {string[]} axes - Axes to home (e.g., ['X', 'Y', 'Z'])
+     * @param {number} timeout - Timeout in ms (default 120s — homing can be slow)
      */
-    async home(axes = []) {
-        if (axes.length === 0) {
-            await this.sendCommand('G28');
-        } else {
-            await this.sendCommand('G28 ' + axes.join(' '));
-        }
-
-        // Wait for homing to complete
-        await new Promise(r => setTimeout(r, 2000));
+    async home(axes = [], timeout = 120000) {
+        const cmd = axes.length === 0 ? 'G28' : 'G28 ' + axes.join(' ');
+        await this.sendCommandAndWait(cmd, timeout);
         return this.requestPosition();
     }
 


### PR DESCRIPTION
Shared baud selector (localStorage-backed, default 250000) added to printer-control, printer-setup, lc-lb-measure, and calibrator. Tools were hardcoded to 115200 which silently broke any printer flashed with the firmware-builder default of 250000.

Also fixes home() to use sendCommandAndWait with a 120s timeout instead of a fire-and-forget sendCommand + 2s sleep, which falsely errored "Position request timeout" on real homing operations.